### PR TITLE
This is no longer required. Stop deleting CRD

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -139,12 +139,6 @@ echo "Beginning deploy..."
 echo "* Applying the multiclusterhub-operator to install Red Hat Advanced Cluster Management for Kubernetes"
 oc apply -k multiclusterhub
 waitForPod "multicluster-operators-application" "" "4/4"
-#Issues #1025 = This is needed to work around the fact that the Subscription Operator incluses the clusters.clusterregistry.k8s.io
-echo "Remove the clusters.clusterregistry.k8s.io CustomResourceDefinition"
-oc get crd clusters.clusterregistry.k8s.io > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-  oc delete crd clusters.clusterregistry.k8s.io
-fi
 
 COMPLETE=1
 if [ "$1" == "--watch" ]; then


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
- Remove work-around for clusterregistry CRD.

**Motivation for the change:**
- No longer required
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->