### PR TITLE
Make subscription check explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Note: This script can be run multiple times and will attempt to continue where i
 
 4. Wait for subscription to be healthy:
     ```bash
-    oc get subscription multiclusterhub-operator-bundle --namespace open-cluster-management -o yaml
+    oc get subscription.operators.coreos.com multiclusterhub-operator-bundle --namespace open-cluster-management -o yaml
     ...
     status:
       catalogHealth:


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update README instructions to reference the `subscription` CRD explicitly

**Motivation for the change:**
The creation of the `subscription.apps.open-cluster-management.io` (AKA `appsub`) CRD overwrites the `subscription` label. Making this command explicit in the README will prevent confusion. (Alternatively, we could use `sub` instead of the full name.)

(See short discussion at https://coreos.slack.com/archives/CUEMEHRA9/p1585058260084000)
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->