### PR TITLE
check for default storageClass and hide aws keys from console output

### DIFF
--- a/demo/spoke/start.sh
+++ b/demo/spoke/start.sh
@@ -99,7 +99,7 @@ if [ "${AWS_ACCESS_KEY}" == "" ]; then
 fi
 
 AWS_ACCESS_KEY=${DEFAULT_AWS_ACCESS_KEY}
-printf "using aws access key: ${AWS_ACCESS_KEY}\n"
+printf "using aws access key: ****\n"
 
 # aws secret access key
 DEFAULT_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
@@ -117,7 +117,7 @@ if [ "${AWS_SECRET_ACCESS_KEY}" == "" ]; then
 fi
 
 AWS_SECRET_ACCESS_KEY=${DEFAULT_AWS_SECRET_ACCESS_KEY}
-printf "using aws secret access key: ${AWS_SECRET_ACCESS_KEY}\n"
+printf "using aws secret access key: ****\n"
 
 # ocp pull secret
 if [ "${OCP_PULL_SECRET}" == "" ]; then
@@ -160,10 +160,10 @@ printf "* Applying CLOUD_REGION (${CLOUD_REGION}) to ./*.yaml\n"
 ${SED} -i "s/<CLOUD_REGION>/${CLOUD_REGION}/g" ./cluster-deployment.yaml
 ${SED} -i "s/<CLOUD_REGION>/${CLOUD_REGION}/g" ./install-config.yaml
 
-printf "* Applying AWS_ACCESS_KEY (${AWS_ACCESS_KEY}) to ./kustomization.yaml\n"
+printf "* Applying AWS_ACCESS_KEY (****) to ./kustomization.yaml\n"
 ${SED} -i "s/<AWS_ACCESS_KEY>/${AWS_ACCESS_KEY}/g" ./kustomization.yaml
 
-printf "* Applying AWS_SECRET_ACCESS_KEY (${AWS_SECRET_ACCESS_KEY}) to ./kustomization.yaml\n"
+printf "* Applying AWS_SECRET_ACCESS_KEY (****) to ./kustomization.yaml\n"
 ${SED} -i "s/<AWS_SECRET_ACCESS_KEY>/${AWS_SECRET_ACCESS_KEY}/g" ./kustomization.yaml
 
 printf "* Applying OCP_PULL_SECRET to ./kustomization.yaml\n"

--- a/start.sh
+++ b/start.sh
@@ -69,11 +69,17 @@ echo "* Using baseDomain: ${HOST_URL}"
 VER=`oc version | grep "Client Version:"`
 echo "* oc CLI ${VER}"
 
-#echo "Pick a namepsace to deploy into"
-#read -r TARGET_NAMESPACE
-#if [ "$TARGET_NAMESPACE" == "" ]; then
-#  TARGET_NAMESPACE=multicluster-system
-#fi
+# ensure default storage class defined on ocp cluster
+SC_RESOLVE=$(oc get sc 2>&1)
+if [[ $SC_RESOLVE =~ (default) ]];
+then
+  echo "OK: Default Storage Class defined"
+else
+  echo "ERROR: No default Storage Class defined."
+  echo "    Add Annotation 'storageclass.kubernetes.io/is-default-class=true' to one of your cluster's storageClass types."
+  echo "    Aborting."
+  exit 1
+fi
 
 if [ ! -f ./prereqs/pull-secret.yaml ]; then
     echo "SECURITY NOTICE: The encrypted dockerconfigjson is stored in ./prereqs/pull-secret.yaml. If you want to change the value, delete the file and run start.sh"


### PR DESCRIPTION
**Description of the change:**
- Check for default storageClass in start.sh script, abort on not found 
   closes issue #20 
- Hide AWS key and secrete key from console output in demo/spoke/start.sh script.

**Motivation for the change:**
- help user avoid confusion if no default storageClass defined in their targeted OCP cluster
- for security reasons hide AWS key and secret key from console output.