### PR TITLE
Display target cluster before uninstall

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo "This script will uninstall Open Cluster Management from the current OpenShift target cluster:"
+oc cluster-info | head -n 1 | awk '{print $NF}'
+echo ""
+
 ./clean-clusters.sh
 
 kubectl delete -k multiclusterhub/ --ignore-not-found


### PR DESCRIPTION
**Description of the change:**
Display the target cluster before proceeding with the uninstall.

**Motivation for the change:**
I'm always worried that I'll wipe out a cluster that isn't mine. This should prevent users from accidentally deleting the wrong cluster.

![image](https://user-images.githubusercontent.com/4671325/78062976-74fb4b00-735d-11ea-9216-c21a12a11fc6.png)

