### PR TITLE
Update start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -13,7 +13,7 @@ function waitForPod() {
     MINUTE=0
     podName=$1
     ignore=$2
-    runnings="$3"
+    running="$3"
     printf "\n#####\nWait for ${podName} to reach running state (4min).\n"
     while [ ${FOUND} -eq 1 ]; do
         # Wait up to 4min, should only take about 20-30s


### PR DESCRIPTION
- Change $runnings to $running

<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
- Fix missing variable, the start.sh script is not waiting for all pods to be online

**Motivation for the change:**
- Could mean we look for results to early and show false errors.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->