### PR TITLE
Update start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -7,6 +7,8 @@
 # ./start.sh --silent, this skips any questions, using the local files to apply the snapshot and secret
 # ./start.sh --watch, this monitors for status during the main deploy of Red Hat ACM
 
+# CONSTANTS
+TOTAL_POD_COUNT=35
 
 function waitForPod() {
     FOUND=1
@@ -177,9 +179,8 @@ if [[ " $@ " =~ " --watch " ]]; then
             fi
         fi
         echo
-        echo "Number of Running Pods  : $RUNNING_PODS"
+        echo "Number of expected Pods : $RUNNING_PODS/$TOTAL_POD_COUNT"
         echo "Pods still NOT running  : ${whatsLeft}"
-        echo "Expected Number of Running Pods  : 35"
         echo "Detected ACM Console URL: https://${CONSOLE_URL}"
         sleep 10
     done


### PR DESCRIPTION
-Adjust podcount labels

<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
```
Number of Running Pods  : 37
Pods still NOT running  : 10
Expected Number of Running Pods  : 35
```
Doesn't look good.
```
Number of Running Pods  : 35
Pods still NOT running  : 14
Expected Number of Running Pods  : 35
```
Changed the output to this:
```
Number of expected Pods : 35/35
Pods still NOT running  : 2
```

**Motivation for the change:**
- Usability
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->