### PR TITLE
force hack script to use bash - mac defaults to zsh and will cause er…

### DIFF
--- a/hack/nuke.sh
+++ b/hack/nuke.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 remove-apiservices () {
   echo "Remove Orphaned Apiservices"
   for apiservice in `kubectl get apiservices 2>/dev/null | grep "False" | awk '{ print $1; }'`; do


### PR DESCRIPTION
…rors

**Description of the change:**
On my re-imaged mac, ksh is default shell.  This causes an error when running `nuke.sh`
```
./nuke.sh: line 10: `remove-apiservices': not a valid identifier
```

Force script to use bash

