### PR TITLE
Change conditional to be more strict with default

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -90,7 +90,7 @@ fi
 
 # ensure default storage class defined on ocp cluster
 SC_RESOLVE=$(oc get sc 2>&1)
-if [[ $SC_RESOLVE =~ (default) ]];
+if [[ $SC_RESOLVE =~ '(default)' ]];
 then
   echo "OK: Default Storage Class defined"
 else


### PR DESCRIPTION
**Description of the change:**

Changed `if [[ $SC_RESOLVE =~ (default) ]];`, to take (default) literal

**Motivation for the change:**

Originally it was letting the conditional pass if user's current project is default when using `./start.sh`.
