### PR TITLE
remove optional version, update operator version to 1.0.0

### DIFF
--- a/multiclusterhub-operator/subscription.yaml
+++ b/multiclusterhub-operator/subscription.yaml
@@ -8,4 +8,4 @@ spec:
   name: multiclusterhub-operator-bundle
   source: open-cluster-management
   sourceNamespace: open-cluster-management
-  startingCSV: multiclusterhub-operator.v0.0.1
+  startingCSV: multiclusterhub-operator.v1.0.0

--- a/multiclusterhub-operator/uninstall.sh
+++ b/multiclusterhub-operator/uninstall.sh
@@ -4,7 +4,7 @@ oc project open-cluster-management
 
 # Remove multicloudhub resources
 oc delete subscriptions.operators.coreos.com multiclusterhub-operator --ignore-not-found
-oc delete csv multiclusterhub-operator.v0.0.1 --ignore-not-found
+oc delete csv multiclusterhub-operator.v1.0.0 --ignore-not-found
 oc delete catalogsource multiclusterhub-operator-registry --ignore-not-found
 oc delete crd multiclusterhubs.operators.open-cluster-management.io --ignore-not-found
 

--- a/multiclusterhub/example-multiclusterhub-cr.yaml
+++ b/multiclusterhub/example-multiclusterhub-cr.yaml
@@ -4,7 +4,6 @@ metadata:
   name: multiclusterhub
   namespace: open-cluster-management
 spec:
-  version: latest
   imageRepository: "quay.io/open-cluster-management"
   imageTagSuffix: SNAPSHOT-2020-04-14-16-26-00
   imagePullPolicy: Always


### PR DESCRIPTION
Related issues:

https://github.com/open-cluster-management/backlog/issues/1219
https://github.com/open-cluster-management/backlog/issues/1607
 
Needs to be merged with:

https://github.com/open-cluster-management/multicloudhub-operator/pull/177