### PR TITLE
subscribe nginx v1.36

### DIFF
--- a/demo/app/devapp/devapp.yaml
+++ b/demo/app/devapp/devapp.yaml
@@ -52,7 +52,7 @@ spec:
   channel: ns-ch/predev-ch
   name: nginx-ingress
   packageFilter:
-    version: "1.20.x"
+    version: "1.36.x"
   placement:
     placementRef:
       kind: PlacementRule


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

subscribe nginx v1.36 as the old v1.20 nginx helm chart is bundling deployment template with apiversion: v1beta1, which is not supported in openshift platform, where deployment with apiversion: v1 is applied 

**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->