### PR TITLE
Add instructions to update rover profile with quay

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Either way you choose to go, you are going to need a `pull-secret`. We are still
 
 2. Generate your pull-secret:
    - ensure you have access to the quay org ([open-cluster-management](https://quay.io/repository/open-cluster-management/multiclusterhub-operator-index?tab=tags))
-     - to request access to [open-cluster-management](https://quay.io/repository/open-cluster-management/multiclusterhub-operator-index?tab=tags) in quay.io please contact us on our Slack Channel [#forum-acm](https://coreos.slack.com/archives/CTDEY6EEA)).
+     - to request access to [open-cluster-management](https://quay.io/repository/open-cluster-management/multiclusterhub-operator-index?tab=tags) in quay.io please ensure your rover profile contains a professional social media link to your quay profile and then contact us on our Slack Channel [#forum-acm](https://coreos.slack.com/archives/CTDEY6EEA)).
    - go to [https://quay.io/user/tpouyer?tab=settings](https://quay.io/user/tpouyer?tab=settings) replacing `tpouyer` with your username
    - click on `Generate Encrypted Password`
    - enter your quay.io password


### PR DESCRIPTION
For the love of Pete, tell us what your quay ID is via rover

<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Tell people to update their rover profile with quay ID

**Motivation for the change:**

Randos come in to #forum-acm and ask for access to quay.  Problem is... we don't have a way to know what their ID is.  So to limit the back-and-forth, tell them how to help themselves first by updating their rover profile.