### PR TITLE
Convert the matchLabels to use strings instead of bools

### DIFF
--- a/resources/policies/policy-container-security.yaml
+++ b/resources/policies/policy-container-security.yaml
@@ -191,4 +191,4 @@ spec:
   clusterSelector:
     matchExpressions: []
     matchLabels:
-      enforcedSecureImages: true
+      enforcedSecureImages: "true"


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

The `PlacementRule` for one of the policies used a label that should have been a `string` but was interpreted as a `bool`. Added quotes to ensure it is read as a `string`.

**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->