### PR TITLE
Resolve "AlreadyExists" error when creating prereq SA on fresh clusters

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -162,6 +162,20 @@ if [[ " $@ " =~ " -t " ]]; then
     exit 0
 fi
 
+printf "\n##### Creating the $TARGET_NAMESPACE namespace\n"
+kubectl create ns $TARGET_NAMESPACE
+
+seconds=0
+while [ -z $(kubectl get sa -n $TARGET_NAMESPACE -o name default) ]; do
+    echo "--- waiting for namespace: $TARGET_NAMESPACE to create with default service account ---"
+    sleep 10
+    (( seconds=seconds+10 ))
+    if [ "$seconds" -gt 60 ]; then
+        echo "--- waited 60 seconds for namespace: $TARGET_NAMESPACE but it never came up with default service account, exiting ---"
+        exit 1;
+    fi
+done;
+
 printf "\n##### Applying prerequisites\n"
 kubectl apply --openapi-patch=true -k prereqs/
 


### PR DESCRIPTION
## Issue Summary

`deploy` s on fresh clusters will fail with an error:
```
##### Applying prerequisites
namespace/open-cluster-management created
secret/multiclusterhub-operator-pull-secret created
Error from server (AlreadyExists): error when creating "prereqs/": serviceaccounts "default" already exists
```

In essence, `kubectl apply -k prereqs/` plans that its going to create the ns and the default service account, but doesn't realize that by creating the ns it has already created the default service account, and needs to update the default sa differently or risk getting an "AlreadyExists" error.  That's the closest theory we have.  It falls apart a bit, because creating the NS and then deleting it, then re-running the deploy repo also works which is interesting to say the least. But either way, pulling the NS creation out of the prereqs and doing it before and polling for ns creation before applying prereqs is our silver bullet for the issue.  

## Fix tested on:

1. Fresh cluster - successfully creates NS and doesn't error.  
2. Cluster where namespace creation takes <60 seconds - polls and then succeeds
3. Cluster where namespace creation never succeeds - polls for 60 seconds then fails gracefully