### PR TITLE
Adding a note to export COMPOSITE_BUNDLE=true if you're deploying 1.X.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Either way you choose to go, you are going to need a `pull-secret`. We are still
 
 We've added a very simple `start.sh` script to make your life easier. 
 
-First, you need to export KUBECONFIG=/path/to/some/cluster/kubeconfig (or do an `oc login` that will set it for you), `deploy` will install to the cluster pointed to by the current KUBECONFIG!  
+First, you need to `export KUBECONFIG=/path/to/some/cluster/kubeconfig` (or do an `oc login` that will set it for you), `deploy` will install to the cluster pointed to by the current KUBECONFIG!  
 
-**If you're deploying a downstream build** `export COMPOSITE_BUNDLE=true`.  Export `CUSTOM_REGISTRY_REPO=acm-d` if you want to deploy the downstream build from a repo other than `open-cluster-management` (which you probably do!).  Make sure you have `snapshot.ver` set to a downstream build, or pass it into the start.sh script!
+**If you're deploying a downstream build or a 1.X.X build of OCM/ACM** `export COMPOSITE_BUNDLE=true`.  Export `CUSTOM_REGISTRY_REPO=acm-d` if you want to deploy the downstream build from a repo other than `open-cluster-management` (which you probably do!).  Make sure you have `snapshot.ver` set to a downstream build, or pass it into the start.sh script!
 
 1. Run the `start.sh` script. You have the following options (use one at a time) when you run the command: 
 


### PR DESCRIPTION
# Summary

Because ACM 1.X.X deploys via an artifact named acm-custom-registry (which uses the COMPOSITE_BUNDLE), you need to set `COMPOSITE_BUNDLE=true` to deploy 1.X.X builds!  Adding a note about this to the readme.  