### PR TITLE
Fix Dynamic Pod Count Polling

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -214,7 +214,7 @@ if [[ " $@ " =~ " --watch " ]]; then
         whatsLeft=`oc -n ${TARGET_NAMESPACE} get pods | grep -v -e "Completed" -e "1/1     Running" -e "2/2     Running" -e "3/3     Running" -e "4/4     Running" -e "READY   STATUS" | wc -l`
         RUNNING_PODS=$(oc -n ${TARGET_NAMESPACE} get pods | grep -v -e "Completed" | tail -n +2 | wc -l | tr -d '[:space:]')
         if [ "https://$CONSOLE_URL" == "https://multicloud-console.apps.${HOST_URL}" ] && [ ${whatsLeft} -eq 0 ]; then
-            if [ $RUNNING_PODS -ge 35 ]; then
+            if [ $RUNNING_PODS -ge ${TOTAL_POD_COUNT} ]; then
                 COMPLETE=0
                 break
             fi
@@ -245,7 +245,7 @@ if [ "${OS}" == "darwin" ]; then
        echo "NOTE: watch executable not found.  Perform \"brew install watch\" to use the command above or use \"./start.sh --watch\" "
     fi
 else
-  echo "Deploying, use \"watch oc -n ${TARGET_NAMESPACE} get pods\" to monitor progress. Expect around 35 pods"
+  echo "Deploying, use \"watch oc -n ${TARGET_NAMESPACE} get pods\" to monitor progress. Expect around ${TOTAL_POD_COUNT} pods"
 fi
 
 


### PR DESCRIPTION
This is a hotfix to make the `--watch` parameter actually obey the detected pod count.  This was missed in an initial PR that modified the env var, we found a location where the env var was not used, instead the pod count was verbosely stated.  Sorry for the double PR, should've caught that the first time 😉 