### PR TITLE
Delete scc objects nuke scripts only, not uninstall

### DIFF
--- a/acm-operator/uninstall.sh
+++ b/acm-operator/uninstall.sh
@@ -39,8 +39,9 @@ oc delete crd applications.app.k8s.io --ignore-not-found
 oc delete crd clusters.clusterregistry.k8s.io --ignore-not-found
 oc get service | grep "multicluster" | awk '{ print $1 }' | xargs oc delete service --wait=false --ignore-not-found
 
-oc get scc | grep "multicluster" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
-oc get scc | grep "multicloud" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
+# delete these objects via nuke script only
+# oc get scc | grep "multicluster" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
+# oc get scc | grep "multicloud" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
 
 # Remove custom registry resources
 oc delete catalogsource $custom_catalog_source --ignore-not-found

--- a/acm-operator/uninstall.sh
+++ b/acm-operator/uninstall.sh
@@ -41,7 +41,6 @@ oc get service | grep "multicluster" | awk '{ print $1 }' | xargs oc delete serv
 
 oc get scc | grep "multicluster" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
 oc get scc | grep "multicloud" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
-oc get scc | grep "kui-proxy" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
 
 # Remove custom registry resources
 oc delete catalogsource $custom_catalog_source --ignore-not-found

--- a/acm-operator/uninstall.sh
+++ b/acm-operator/uninstall.sh
@@ -41,6 +41,7 @@ oc get service | grep "multicluster" | awk '{ print $1 }' | xargs oc delete serv
 
 oc get scc | grep "multicluster" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
 oc get scc | grep "multicloud" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
+oc get scc | grep "kui-proxy" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
 
 # Remove custom registry resources
 oc delete catalogsource $custom_catalog_source --ignore-not-found

--- a/hack/nuke.sh
+++ b/hack/nuke.sh
@@ -98,6 +98,7 @@ oc get csv | grep "etcd" | awk '{ print $1 }' | xargs oc delete csv --wait=false
 oc get crd | grep "etcd" | awk '{ print $1 }' | xargs oc delete crd --wait=false --ignore-not-found || true
 oc get scc | grep "multicluster" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found || true
 oc get scc | grep "multicloud" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found || true
+oc get scc | grep "kui-proxy" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found || true
 oc get crd | grep "certmanager" | awk '{ print $1 }' | xargs oc delete crd --wait=false --ignore-not-found || true
 oc get crd | grep "mcm" | awk '{ print $1 }' | xargs oc delete crd --wait=false --ignore-not-found || true
 oc get crd | grep "ibm" | awk '{ print $1 }' | xargs oc delete crd --wait=false --ignore-not-found || true

--- a/multicluster-hub-operator/uninstall.sh
+++ b/multicluster-hub-operator/uninstall.sh
@@ -41,7 +41,6 @@ oc get service | grep "multicluster" | awk '{ print $1 }' | xargs oc delete serv
 
 oc get scc | grep "multicluster" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
 oc get scc | grep "multicloud" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
-oc get scc | grep "kui-proxy" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
 
 # Remove custom registry resources
 oc delete catalogsource $custom_catalog_source --ignore-not-found

--- a/multicluster-hub-operator/uninstall.sh
+++ b/multicluster-hub-operator/uninstall.sh
@@ -39,8 +39,9 @@ oc delete crd applications.app.k8s.io --ignore-not-found
 oc delete crd clusters.clusterregistry.k8s.io --ignore-not-found
 oc get service | grep "multicluster" | awk '{ print $1 }' | xargs oc delete service --wait=false --ignore-not-found
 
-oc get scc | grep "multicluster" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
-oc get scc | grep "multicloud" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
+# Only delete these objects via nuke script
+# oc get scc | grep "multicluster" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
+# oc get scc | grep "multicloud" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
 
 # Remove custom registry resources
 oc delete catalogsource $custom_catalog_source --ignore-not-found

--- a/multicluster-hub-operator/uninstall.sh
+++ b/multicluster-hub-operator/uninstall.sh
@@ -41,6 +41,7 @@ oc get service | grep "multicluster" | awk '{ print $1 }' | xargs oc delete serv
 
 oc get scc | grep "multicluster" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
 oc get scc | grep "multicloud" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
+oc get scc | grep "kui-proxy" | awk '{ print $1 }' | xargs oc delete scc --wait=false --ignore-not-found
 
 # Remove custom registry resources
 oc delete catalogsource $custom_catalog_source --ignore-not-found


### PR DESCRIPTION
**Description of the change:**
Delete `kui-proxy-scc` object via nuke script

**Motivation for the change:**

The Canary builds are reporting that `kui-proxy-scc` object was not getting cleaned up on uninstall, and subsequent installs are failing. Ref: https://github.com/open-cluster-management/backlog/issues/2878