### PR TITLE
Add "mch-imageRepository" annotation to mch resource. 

### DIFF
--- a/multiclusterhub/example-multiclusterhub-cr.yaml
+++ b/multiclusterhub/example-multiclusterhub-cr.yaml
@@ -3,6 +3,8 @@ kind: MultiClusterHub
 metadata:
   name: multiclusterhub
   namespace: open-cluster-management
+  annotations:
+    "mch-imageRepository": "quay.io/open-cluster-management"
 spec:
   imagePullSecret: multiclusterhub-operator-pull-secret
   

--- a/start.sh
+++ b/start.sh
@@ -167,6 +167,7 @@ echo "* Applying SUBSCRIPTION_CHANNEL to multiclusterhub-operator subscription"
 ${SED} -i "s|channel: .*$|channel: ${SUBSCRIPTION_CHANNEL}|g" ./$OPERATOR_DIRECTORY/subscription.yaml
 echo "* Applying multicluster-hub-cr values"
 ${SED} -i "s/example-multiclusterhub/multiclusterhub/" ./multiclusterhub/example-multiclusterhub-cr.yaml
+${SED} -i f"s|\"mch-imageRepository\": .*$|\"mch-imageRepository\": {CUSTOM_REGISTRY_REPO}|g" ./multiclusterhub/example-multiclusterhub-cr.yaml
 
 if [[ " $@ " =~ " -t " ]]; then
     echo "* Test mode, see yaml files for updates"

--- a/start.sh
+++ b/start.sh
@@ -129,7 +129,21 @@ if [ "${DEFAULT_SNAPSHOT}" == "MUST_PROVIDE_SNAPSHOT" ]; then
     exit 2
 fi
 SNAPSHOT_PREFIX=${DEFAULT_SNAPSHOT%%\-*}
+
+# Set the custom registry repo, defaulted to quay.io/open-cluster-management, but accomodate custom config focused on quay.io/acm-d for donwstream tests
+CUSTOM_REGISTRY_REPO=${CUSTOM_REGISTRY_REPO:-"quay.io/open-cluster-management"}
+# Default COMPOSITE_BUNDLE to true
+COMPOSITE_BUNDLE=${COMPOSITE_BUNDLE:-"true"}
+
+# If the user sets the COMPOSITE_BUNDLE flag to "true", then set to the `acm` variants of variables, otherwise the multicluster-hub version.  
+if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then OPERATOR_DIRECTORY="acm-operator"; else OPERATOR_DIRECTORY="multicluster-hub-operator"; fi;
+if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then CUSTOM_REGISTRY_IMAGE="acm-custom-registry"; else CUSTOM_REGISTRY_IMAGE="multicluster-hub-custom-registry"; fi;
+
+# Set the subscription channel, defaulted to snapshot-2.0
+if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then SUBSCRIPTION_CHANNEL="release-2.0"; else SUBSCRIPTION_CHANNEL="snapshot-2.0"; fi;
+
 echo "* Downstream: ${DOWNSTREAM}   Release Version: $SNAPSHOT_PREFIX"
+echo "* Composite Bundle: $COMPOSITE_BUNDLE   Image Registry (CUSTOM_REGISTRY_REPO): $CUSTOM_REGISTRY_REPO"
 if [[ (! $SNAPSHOT_PREFIX == *.*.*) && ("$DOWNSTREAM" != "true") ]]; then
     echo "ERROR: invalid SNAPSHOT format... snapshot must begin with 'X.0.0-' not '$SNAPSHOT_PREFIX', if DOWNSTREAM isn't set"
     exit 1
@@ -145,18 +159,6 @@ else
     echo "Snapshot doesn't contain a version number we recognize, looking for the 1.X release pod count of ${TOTAL_POD_COUNT} if wait is selected."
 fi
 
-# Set the custom registry repo, defaulted to quay.io/open-cluster-management, but accomodate custom config focused on quay.io/acm-d for donwstream tests
-CUSTOM_REGISTRY_REPO=${CUSTOM_REGISTRY_REPO:-"quay.io/open-cluster-management"}
-# Default COMPOSITE_BUNDLE to true
-COMPOSITE_BUNDLE=${COMPOSITE_BUNDLE:-"true"}
-
-# If the user sets the COMPOSITE_BUNDLE flag to "true", then set to the `acm` variants of variables, otherwise the multicluster-hub version.  
-if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then OPERATOR_DIRECTORY="acm-operator"; else OPERATOR_DIRECTORY="multicluster-hub-operator"; fi;
-if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then CUSTOM_REGISTRY_IMAGE="acm-custom-registry"; else CUSTOM_REGISTRY_IMAGE="multicluster-hub-custom-registry"; fi;
-
-# Set the subscription channel, defaulted to snapshot-2.0
-if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then SUBSCRIPTION_CHANNEL="release-2.0"; else SUBSCRIPTION_CHANNEL="snapshot-2.0"; fi;
-
 printf "* Using: ${DEFAULT_SNAPSHOT}\n\n"
 
 echo "* Applying SNAPSHOT to multiclusterhub-operator subscription"
@@ -167,7 +169,7 @@ echo "* Applying SUBSCRIPTION_CHANNEL to multiclusterhub-operator subscription"
 ${SED} -i "s|channel: .*$|channel: ${SUBSCRIPTION_CHANNEL}|g" ./$OPERATOR_DIRECTORY/subscription.yaml
 echo "* Applying multicluster-hub-cr values"
 ${SED} -i "s/example-multiclusterhub/multiclusterhub/" ./multiclusterhub/example-multiclusterhub-cr.yaml
-${SED} -i "s|\"mch-imageRepository\": .*$|\"mch-imageRepository\": ${CUSTOM_REGISTRY_REPO}|g" ./multiclusterhub/example-multiclusterhub-cr.yaml
+${SED} -i "s|\"mch-imageRepository\": .*$|\"mch-imageRepository\": \"${CUSTOM_REGISTRY_REPO}\"|g" ./multiclusterhub/example-multiclusterhub-cr.yaml
 
 if [[ " $@ " =~ " -t " ]]; then
     echo "* Test mode, see yaml files for updates"

--- a/start.sh
+++ b/start.sh
@@ -167,7 +167,7 @@ echo "* Applying SUBSCRIPTION_CHANNEL to multiclusterhub-operator subscription"
 ${SED} -i "s|channel: .*$|channel: ${SUBSCRIPTION_CHANNEL}|g" ./$OPERATOR_DIRECTORY/subscription.yaml
 echo "* Applying multicluster-hub-cr values"
 ${SED} -i "s/example-multiclusterhub/multiclusterhub/" ./multiclusterhub/example-multiclusterhub-cr.yaml
-${SED} -i f"s|\"mch-imageRepository\": .*$|\"mch-imageRepository\": {CUSTOM_REGISTRY_REPO}|g" ./multiclusterhub/example-multiclusterhub-cr.yaml
+${SED} -i "s|\"mch-imageRepository\": .*$|\"mch-imageRepository\": ${CUSTOM_REGISTRY_REPO}|g" ./multiclusterhub/example-multiclusterhub-cr.yaml
 
 if [[ " $@ " =~ " -t " ]]; then
     echo "* Test mode, see yaml files for updates"


### PR DESCRIPTION
## Overview

These changes will automatically inject the CUSTOM_REGISTRY_REPO (default quay.io/open-cluster-management) as the "mch-imageRepository" annotation in the MCH resource that is applied by the deploy repo.  This should allow successful deploys via Hive with downstream builds from quay.io/acm-d.  