### PR TITLE
check for the correct pod count on 2.1.X deploys  as well as 2.0.X deploys

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -154,7 +154,7 @@ fi
 # Change our expected pod count based on what version snapshot we detect, defaulting to 1.0 (smallest number of pods as of writing)
 if [[ $DEFAULT_SNAPSHOT == *1.0* ]]; then
     TOTAL_POD_COUNT=${TOTAL_POD_COUNT_1X}
-elif [[ $DEFAULT_SNAPSHOT == *2.0* ]]; then
+elif [[ $DEFAULT_SNAPSHOT == *2.* ]]; then
     TOTAL_POD_COUNT=${TOTAL_POD_COUNT_2X}
 else
     TOTAL_POD_COUNT=${TOTAL_POD_COUNT_1X}


### PR DESCRIPTION
It does what it says on the box again!