### PR TITLE
Fix version detection

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -150,9 +150,9 @@ if [[ (! $SNAPSHOT_PREFIX == *.*.*) && ("$DOWNSTREAM" != "true") ]]; then
 fi
 
 # Change our expected pod count based on what version snapshot we detect, defaulting to 1.0 (smallest number of pods as of writing)
-if [[ $DEFAULT_SNAPSHOT == *1.0* ]]; then
+if [[ $DEFAULT_SNAPSHOT == 1.0* ]]; then
     TOTAL_POD_COUNT=${TOTAL_POD_COUNT_1X}
-elif [[ $DEFAULT_SNAPSHOT == *2.* ]]; then
+elif [[ $DEFAULT_SNAPSHOT == 2.* ]]; then
     TOTAL_POD_COUNT=${TOTAL_POD_COUNT_2X}
 else
     TOTAL_POD_COUNT=${TOTAL_POD_COUNT_1X}


### PR DESCRIPTION
Fixes an issue where 2.1.0 builds think they're 1.0.X builds because regex is a lossy art.  