### PR TITLE
Auto-Detect Subscription Channel for Composite and Non-Composite Bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ First, you need to `export KUBECONFIG=/path/to/some/cluster/kubeconfig` (or do a
 
 ### Downstream
 
-To deploy a downstream build from `quay.io/acm-d`, you need to ensure that your OCP cluster meets two conditions:
+To deploy a downstream build from `quay.io/acm-d`, you need to `export COMPOSITE_BUNDLE=true` and ensure that your OCP cluster meets two conditions:
 1. The cluster must have an ImageContentSourcePolicy as follows (**Caution**: if you modify this on a running cluster, it will cause a rolling restart of all nodes).  To apply the ImageContentSourcePolicy, run `oc apply -f icsp.yaml` with `icsp.yaml` containing the following:
 
 **For 1.X**

--- a/start.sh
+++ b/start.sh
@@ -137,14 +137,21 @@ CUSTOM_REGISTRY_REPO=${CUSTOM_REGISTRY_REPO:-"quay.io/open-cluster-management"}
 if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then OPERATOR_DIRECTORY="acm-operator"; else OPERATOR_DIRECTORY="multicluster-hub-operator"; fi;
 if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then CUSTOM_REGISTRY_IMAGE="acm-custom-registry"; else CUSTOM_REGISTRY_IMAGE="multicluster-hub-custom-registry"; fi;
 
-# Set the subscription channel if the variable wasn't defined as input, defaulted to snapshot-2.0
+# Set the subscription channel if the variable wasn't defined as input, defaulted to snapshot-<release-version>
 if [ -z "$SUBSCRIPTION_CHANNEL" ]; then
-    SUBSCRIPTION_CHANNEL_VERSION=$(echo SNAPSHOT_PREFIX | sed -nr "s/v{0,1}([0-9]+\.[0-9]+)\.{0,1}[0-9]*.*/\1/p")
+    SUBSCRIPTION_CHANNEL_VERSION=$(echo ${SNAPSHOT_PREFIX} | ${SED} -nr "s/v{0,1}([0-9]+\.[0-9]+)\.{0,1}[0-9]*.*/\1/p")
     if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then 
-        SUBSCRIPTION_CHANNEL="release-${SUBSCRIPTION_CHANNEL_VERSION}"; 
+        SUBSCRIPTION_CHANNEL_PREFIX="release"; 
     else 
-        SUBSCRIPTION_CHANNEL="snapshot-${SUBSCRIPTION_CHANNEL_VERSION}";
+        SUBSCRIPTION_CHANNEL_PREFIX="snapshot";
     fi;
+
+    SUBSCRIPTION_CHANNEL="${SUBSCRIPTION_CHANNEL_PREFIX}-${SUBSCRIPTION_CHANNEL_VERSION}"
+
+    if [[ ! ( $SUBSCRIPTION_CHANNEL_VERSION =~ [0-9]+\.[0-9]+ ) ]]; then
+        echo "Failed to detect SUBSCRIPTION_CHANNEL, we detected ${SUBSCRIPTION_CHANNEL} which doesn't seem correct.  Try exporting SUBSCRIPTION_CHANNEL and rerunning."
+        exit 1
+    fi
 fi
 
 echo "* Downstream: ${DOWNSTREAM}   Release Version: $SNAPSHOT_PREFIX"

--- a/start.sh
+++ b/start.sh
@@ -139,7 +139,12 @@ if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then CUSTOM_REGISTRY_IMAGE="acm-custom-r
 
 # Set the subscription channel if the variable wasn't defined as input, defaulted to snapshot-2.0
 if [ -z "$SUBSCRIPTION_CHANNEL" ]; then
-    if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then SUBSCRIPTION_CHANNEL="release-2.0"; else SUBSCRIPTION_CHANNEL="snapshot-2.0"; fi;
+    SUBSCRIPTION_CHANNEL_VERSION=$(echo SNAPSHOT_PREFIX | sed -nr "s/v{0,1}([0-9]+\.[0-9]+)\.{0,1}[0-9]*.*/\1/p")
+    if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then 
+        SUBSCRIPTION_CHANNEL="release-${SUBSCRIPTION_CHANNEL_VERSION}"; 
+    else 
+        SUBSCRIPTION_CHANNEL="snapshot-${SUBSCRIPTION_CHANNEL_VERSION}";
+    fi;
 fi
 
 echo "* Downstream: ${DOWNSTREAM}   Release Version: $SNAPSHOT_PREFIX"

--- a/start.sh
+++ b/start.sh
@@ -203,7 +203,7 @@ while [ -z $(kubectl get sa -n $TARGET_NAMESPACE -o name default) ]; do
 done;
 
 if [[ "$COMPOSITE_BUNDLE" != "true" ]]; then
-    printf "\n##### Applying community operator subscriptions\n\n"
+    printf "\n##### Applying community operator subscriptions\n"
     oc apply -k community-subscriptions -n ${TARGET_NAMESPACE} 
 fi
 


### PR DESCRIPTION
## Overview

Resolves https://github.com/open-cluster-management/backlog/issues/3638

This PR detects the major release version of ACM/OCM from the snapshot text and forms a subscription channel based on the value of the COMPOSITE_BUNDLE toggle.  This should resolve issues when deploying the composite vs non-composite bundle upstream and should also allow greater flexibility moving forward to new OCM versions. This PR also allows the user to override the subscription channel wholesale. 

## Tested with
latest 2.1.0 upstream w/ COMPOSITE_BUNDLE=true
latest 2.1.0 upstream w/ COMPOSITE_BUNDLE=false
latest 2.0.0 upstream w/ COMPOSITE_BUNDLE=true
latest 2.0.0 upstream w/ COMPOSITE_BUNDLE=false
v2.0.0-RC3 downstream w/ COMPOSITE_BUNDLE=true