### PR TITLE
update clean-clusters.sh to delete managedcluster 

### DIFF
--- a/clean-clusters.sh
+++ b/clean-clusters.sh
@@ -32,7 +32,7 @@ for clusterName in `oc get clusterDeployments --all-namespaces --ignore-not-foun
     fi
 done
 
-echo "Detaching imported clusters"
+echo "Detaching imported clusters (rhacm 1.0)"
 for clusterName in `oc get clusters --all-namespaces --ignore-not-found | grep -v "NAMESPACE" | awk '{ print $1 }'`; do
     printf " Detaching cluster ${clusterName}\n  "
     if [ $CLEAN_RESOURCES ]; then
@@ -50,6 +50,24 @@ for clusterName in `oc get endpointconfig --all-namespaces --ignore-not-found | 
         oc -n ${clusterName} delete cluster ${clusterName}
         printf "  "  #Spacing
         oc delete namespace ${clusterName} --wait=false
+    fi
+done
+
+echo "Detaching imported clusters (rhacm 2.0+)"
+for clusterName in `oc get managedcluster --ignore-not-found | grep -v "NAME" | awk '{ print $1 }'`; do
+    printf " Detaching cluster ${clusterName}\n  "
+    if [ $CLEAN_RESOURCES ]; then
+        oc delete managedcluster ${clusterName} --wait=false
+        printf "  "  #Spacing
+    fi
+done
+
+echo "Second pass cleaning, by klusterletaddonconfig"
+for clusterName in `oc get klusterletaddonconfig --all-namespaces --ignore-not-found | grep -v "NAMESPACE" | awk '{ print $1 }'`; do
+    printf " Removing addons on cluster ${clusterName}\n  "
+    if [ $CLEAN_RESOURCES ]; then
+        oc -n ${clusterName} delete klusterletaddonconfig ${clusterName} --wait=false
+        printf "  "  #Spacing
     fi
 done
 

--- a/clean-clusters.sh
+++ b/clean-clusters.sh
@@ -59,8 +59,8 @@ for clusterName in `oc get managedcluster --ignore-not-found | grep -v "NAME" | 
     if [ $CLEAN_RESOURCES ]; then
         DELETE_MANAGEDCLUSTER=1
         oc delete managedcluster ${clusterName} --wait=false
-        oc -n ${clusterName} delete klusterletaddonconfig ${clusterName} --wait=false
         printf "  "  #Spacing
+        oc -n ${clusterName} delete klusterletaddonconfig ${clusterName} --wait=false
     fi
 done
 

--- a/clean-clusters.sh
+++ b/clean-clusters.sh
@@ -57,19 +57,49 @@ echo "Detaching imported clusters (rhacm 2.0+)"
 for clusterName in `oc get managedcluster --ignore-not-found | grep -v "NAME" | awk '{ print $1 }'`; do
     printf " Detaching cluster ${clusterName}\n  "
     if [ $CLEAN_RESOURCES ]; then
+        DELETE_MANAGEDCLUSTER=1
         oc delete managedcluster ${clusterName} --wait=false
-        printf "  "  #Spacing
-    fi
-done
-
-echo "Second pass cleaning, by klusterletaddonconfig"
-for clusterName in `oc get klusterletaddonconfig --all-namespaces --ignore-not-found | grep -v "NAMESPACE" | awk '{ print $1 }'`; do
-    printf " Removing addons on cluster ${clusterName}\n  "
-    if [ $CLEAN_RESOURCES ]; then
         oc -n ${clusterName} delete klusterletaddonconfig ${clusterName} --wait=false
         printf "  "  #Spacing
     fi
 done
+
+if [ $DELETE_MANAGEDCLUSTER ] ; then
+    echo "Wait 100 seconds"
+    sleep 100
+fi
+
+echo "Deleting manifestworks"
+for clusterName in `oc get managedcluster --ignore-not-found | grep -v "NAME" | awk '{ print $1 }'`; do
+    printf " Removing manifestworks in ${clusterName}\n  "
+    if [ $CLEAN_RESOURCES ]; then
+        oc delete manifestwork -n ${clusterName} --wait=false --all
+        printf "  "  #Spacing
+        oc delete lease -n ${clusterName} cluster-lease-${clusterName}
+        printf "  "  #Spacing
+        oc delete ns ${clusterName} --wait=false
+    fi
+done
+
+if [ $DELETE_MANAGEDCLUSTER ] ; then
+    echo "Wait 20 seconds"
+    sleep 20
+fi
+
+echo "Force deleting all resources"
+for clusterName in  `oc get managedcluster --ignore-not-found | grep -v "NAME" | awk '{ print $1 }'`; do
+    printf " Force removing all manifestwork, klusterletaddonconfig on cluster ${clusterName}\n  "
+    if [ $CLEAN_RESOURCES ]; then
+        oc get manifestwork -n  ${clusterName} | grep -v NAME | awk '{print $1}' | xargs -n1 oc patch manifestwork -n  ${clusterName} -p '{"metadata":{"finalizers":[]}}' --type=merge
+        printf "  "  #Spacing
+        oc patch klusterletaddonconfig -n ${clusterName} ${clusterName} -p '{"metadata":{"finalizers":[]}}' --type=merge
+        printf "  "  #Spacing
+        oc patch managedcluster -n ${clusterName} ${clusterName} -p '{"metadata":{"finalizers":[]}}' --type=merge
+    fi
+done
+sleep 5
+
+
 
 echo "Done!"
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Added deletion of managedcluster & klusterletaddonconfig
  (wait 120 seconds & force delete)

**Motivation for the change:**
Current ./uninstall.sh doesn't delete managedcluster, with the latest installer webhook changes, the uninstall.sh  can be not working properly.

Tested it can uninstall rhacm 2.0/2.1 with created/imported clusters

**Note:** I'm not sure do we still support rhacm 1.0's uninstall, so I didn't remove the old cluster deletion logic.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->