### PR TITLE
Fix typo in managed cleanup script log message

### DIFF
--- a/hack/cleanup-managed-cluster.sh
+++ b/hack/cleanup-managed-cluster.sh
@@ -31,14 +31,14 @@ component_crds=(
 )
 
 for crd in "${component_crds[@]}"; do
-	echo "force delete all CustomResourceDefination ${crd} resources..."
+	echo "force delete all CustomResourceDefinition ${crd} resources..."
 	for resource in `${KUBECTL} get ${crd} -o name -n ${OPERATOR_NAMESPACE}`; do
 		echo "attempt to delete ${crd} resource ${resource}..."
 		${KUBECTL} delete ${resource} -n ${OPERATOR_NAMESPACE} --timeout=30s
 		echo "force remove ${crd} resource ${resource}..."
 		${KUBECTL} patch ${resource} -n ${OPERATOR_NAMESPACE} --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
 	done
-	echo "force delete all CustomResourceDefination ${crd} resources..."
+	echo "force delete all CustomResourceDefinition ${crd} resources..."
 	${KUBECTL} delete crd ${crd}
 done
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Fix minor typo in log message: `CustomResourceDefination` --> `CustomResourceDefinition`

**Motivation for the change:**
This script is now documented in the RHACM docs, so we should have it as polished as possible.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->