### PR TITLE
Update nuke.sh

### DIFF
--- a/hack/nuke.sh
+++ b/hack/nuke.sh
@@ -125,6 +125,9 @@ oc get mutatingwebhookconfiguration | grep "cert-manager" | awk '{ print $1 }' |
 cd ../
 echo DESTROY | ./uninstall.sh || true
 
+# klusterlet-addon-controller webhook
+for webhook in $(oc get validatingwebhookconfiguration | grep klusterlet-addon-controller | cut -f 1 -d ' '); do oc delete validatingwebhookconfiguration $webhook --ignore-not-found || true; done
+
 # cert-manager cert-manager-webhook
 for webhook in $(oc get validatingwebhookconfiguration | grep cert-manager | cut -f 1 -d ' '); do oc delete validatingwebhookconfiguration $webhook --ignore-not-found || true; done
 for webhook in $(oc get mutatingwebhookconfiguration | grep "cert-manager" | cut -f 1 -d ' '); do oc delete mutatingwebhookconfiguration $webhook --ignore-not-found || true; done


### PR DESCRIPTION
added deletion of klusterlet-addon-controller webhook

<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Added deletion of klusterlet-addon-controller webhook in nuke.sh
(copied & modified keyword of cert-manager webhook deletion code)

**Motivation for the change:**
so 2.1.0 uninstall may have webhook leftover, and it blocks future reinstall & canary builds.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->