### PR TITLE
Add the mchImageRepository env var to the installer test run

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -240,6 +240,7 @@ docker run --network host \
 	--env TEST_MODE=${TEST_MODE} \
 	--env full_test_suite="false" \
 	--env waitInMinutes=10 \
+	--env mchImageRepository=${CUSTOM_REGISTRY_REPO} \
 	--volume ${KUBECONFIG}:/opt/.kube/config \
 	--volume ${RESULTS_DIR}:/usr/src/app/test/results \
 	quay.io/open-cluster-management/multiclusterhub-operator-tests:${INSTALLER_IMAGE_TAG}


### PR DESCRIPTION
## Overview

The installer tests were recently updated to set the mch-imageRepository parameter to resolve downstream snapshot hive provision+import scenarios.  This will fix installer-test-driven downstream canaries.  