### PR TITLE
Move installer test results file mount destination

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -242,7 +242,7 @@ docker run --network host \
 	--env waitInMinutes=10 \
 	--env mchImageRepository=${CUSTOM_REGISTRY_REPO} \
 	--volume ${KUBECONFIG}:/opt/.kube/config \
-	--volume ${RESULTS_DIR}:/usr/src/app/test/results \
+	--volume ${RESULTS_DIR}:/go/src/github.com/open-cluster-management/multicloudhub-operator/test/results/ \
 	quay.io/open-cluster-management/multiclusterhub-operator-tests:${INSTALLER_IMAGE_TAG}
 
 ls -la ${RESULTS_DIR}


### PR DESCRIPTION
## Overview

The installer tests were updated to include their entire codebase, resulting in a change in results file destination.  This change will change the mount destination for the results directory to reflect their internal changes.  