### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ spec:
     source: registry.redhat.io/rhacm1-tech-preview
   - mirrors:
     - registry.redhat.io/openshift4/ose-oauth-proxy
-    source: registry.access.redhat.com/openshfit4/ose-oauth-proxy
+    source: registry.access.redhat.com/openshift4/ose-oauth-proxy
 ```
 
 **For 2.X**
@@ -126,7 +126,7 @@ spec:
     source: registry.redhat.io/rhacm2
   - mirrors:
     - registry.redhat.io/openshift4/ose-oauth-proxy
-    source: registry.access.redhat.com/openshfit4/ose-oauth-proxy
+    source: registry.access.redhat.com/openshift4/ose-oauth-proxy
 ```
 
 2. Ensure that the main pull secret for your OpenShift cluster has pull access to `quay.io/acm-d` in an entry for `quay.io:443`.  Your main pull secret should look something like this (**Caution**: if you apply this on a pre-existing cluster, it will cause a rolling restart of all nodes).  You have to edit the pull secret via the `oc` cli, OpenShift console (recommended) or [bootstrap repo](https://github.com/open-cluster-management/bootstrap#how-to-use) at cluster create time:


### PR DESCRIPTION
made two changes to spelling typos on 
`openshfit` in the  Downstream ICSP yaml   source: registry.access.redhat.com/openshift4/ose-oauth-proxy

<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->