### PR TITLE
about 75% of the time I uninstall, this command needs to be run manually

### DIFF
--- a/multiclusterhub/uninstall.sh
+++ b/multiclusterhub/uninstall.sh
@@ -118,7 +118,7 @@ oc delete namespace hive --wait=false --ignore-not-found
 #Additonal cleanup
 #oc delete crd userpreferences.console.open-cluster-management.io --ignore-not-found || true
 #oc delete ConsoleLink acm-console-link --ignore-not-found || true
-#oc delete OAuthClient multicloudingress --ignore-not-found || true
+oc delete OAuthClient multicloudingress --ignore-not-found || true
 
 # Sleep for 2 minutes to ensure that the deletions complete before any more cleanup occurs.  
 sleep 120


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
I was finding about 70% of my uninstalls did not remove the oauth resource.

**Motivation for the change:**
If it is not removed, the ingress chart will not deploy on your next attempt.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:

-->