### PR TITLE
Readme update to base64 encoding to avoid line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ spec:
 
 #### 2.X.X
 
-**If you're deploying a downstream build of 2.X.X** `export CUSTOM_REGISTRY_REPO="quay.io:443/acm-d"`.  Also `export QUAY_TOKEN=<a quay token with quay.io:443 as the auth domain>`.  In order to get this QUAY_TOKEN, go to your quay.io "Account Settings" page by selecting your username/icon in the top right corner of the page, then "Generate Encrypted Password".  Choose "Kubernetes Secret" and copy just secret text that follows `.dockerconfigjson:`, `export DOCKER_CONFIG=` this value.  Now, `export QUAY_TOKEN=$(echo $DOCKER_CONFIG | base64 -d | sed "s/quay\.io/quay\.io:443/g" | base64)`.  
+**If you're deploying a downstream build of 2.X.X** `export CUSTOM_REGISTRY_REPO="quay.io:443/acm-d"`.  Also `export QUAY_TOKEN=<a quay token with quay.io:443 as the auth domain>`.  In order to get this QUAY_TOKEN, go to your quay.io "Account Settings" page by selecting your username/icon in the top right corner of the page, then "Generate Encrypted Password".  Choose "Kubernetes Secret" and copy just secret text that follows `.dockerconfigjson:`, `export DOCKER_CONFIG=` this value.  Now, `export QUAY_TOKEN=$(echo $DOCKER_CONFIG | base64 -d | sed "s/quay\.io/quay\.io:443/g" | base64 -w 0)`.  
 
 ### Running start.sh
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,11 @@ spec:
 
 #### 2.X.X
 
-**If you're deploying a downstream build of 2.X.X** `export CUSTOM_REGISTRY_REPO="quay.io:443/acm-d"`.  Also `export QUAY_TOKEN=<a quay token with quay.io:443 as the auth domain>`.  In order to get this QUAY_TOKEN, go to your quay.io "Account Settings" page by selecting your username/icon in the top right corner of the page, then "Generate Encrypted Password".  Choose "Kubernetes Secret" and copy just secret text that follows `.dockerconfigjson:`, `export DOCKER_CONFIG=` this value.  Now, `export QUAY_TOKEN=$(echo $DOCKER_CONFIG | base64 -d | sed "s/quay\.io/quay\.io:443/g" | base64 -w 0)`.  
+**If you're deploying a downstream build of 2.X.X** `export CUSTOM_REGISTRY_REPO="quay.io:443/acm-d"`.  Also `export QUAY_TOKEN=<a quay token with quay.io:443 as the auth domain>`.  In order to get this QUAY_TOKEN, go to your quay.io "Account Settings" page by selecting your username/icon in the top right corner of the page, then "Generate Encrypted Password".  Choose "Kubernetes Secret" and copy just secret text that follows `.dockerconfigjson:`, `export DOCKER_CONFIG=` this value.  
+
+Now, `export QUAY_TOKEN=$(echo $DOCKER_CONFIG | base64 -d | sed "s/quay\.io/quay\.io:443/g" | base64)`.  
+
+(On Linux, use `export QUAY_TOKEN=$(echo $DOCKER_CONFIG | base64 -d | sed "s/quay\.io/quay\.io:443/g" | base64 -w 0)` to ensure that there are no line breaks in the base64 encoded token)
 
 ### Running start.sh
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Fix for downstream ACM 2.x instructions to use `base64 -w 0` instead of just `base64` this will ensure there are no line breaks when doing a base64 encoding on the QUAY_TOKEN.

**Motivation for the change:**
Was causing issues when the base64 encoded value is broken up into different lines when deploying a downstream build.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->