### PR TITLE
[hotfix] replay COMPOSITE_BUNDLE default that was backed out in a previous merge

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -12,6 +12,9 @@ TOTAL_POD_COUNT_1X=35
 TOTAL_POD_COUNT_2X=55
 POLL_DURATION_21X=1200
 
+# Global Variables with Defaults
+COMPOSITE_BUNDLE=${COMPOSITE_BUNDLE:-"true"}
+
 function waitForPod() {
     FOUND=1
     MINUTE=0


### PR DESCRIPTION
## Overview

Our new default value for `COMPOSITE_BUNDLE` was backed out in the previous PR, we need to replay it over the new changes.  