### PR TITLE
Fix a typo in the ICSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ spec:
     source: registry.redhat.io/rhacm1-tech-preview
   - mirrors:
     - registry.redhat.io/openshift4/ose-oauth-proxy
-    source: registry.access.redhat.com/openshfit4/ose-oauth-proxy
+    source: registry.access.redhat.com/openshift4/ose-oauth-proxy
 ```
 
 **For 2.X**
@@ -128,7 +128,7 @@ spec:
     source: registry.redhat.io/rhacm2
   - mirrors:
     - registry.redhat.io/openshift4/ose-oauth-proxy
-    source: registry.access.redhat.com/openshfit4/ose-oauth-proxy
+    source: registry.access.redhat.com/openshift4/ose-oauth-proxy
 ```
 
 2. Ensure that the main pull secret for your OpenShift cluster has pull access to `quay.io/acm-d` in an entry for `quay.io:443`.  Your main pull secret should look something like this (**Caution**: if you apply this on a pre-existing cluster, it will cause a rolling restart of all nodes).  You have to edit the pull secret via the `oc` cli, OpenShift console (recommended) or [bootstrap repo](https://github.com/open-cluster-management/bootstrap#how-to-use) at cluster create time:


### PR DESCRIPTION
## Summary

We tell the user to create an ICSP which, inadvertently, included a typo referencing `openshfit4` instead of `openshift4`.  