### PR TITLE
add option to keep provider connections

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,30 @@
 #!/bin/bash
 
+# Parameters
+# -k, --keep-providers Keeping all provider connections that are not in Advanced Cluster Management namespaces.
+
+
+KEEP_PROVIDERS=0
+
+# save args to pass to called scripts
+args=("$@")
+
+# Parse command line arguments
+for arg in "$@"
+do
+    case $arg in
+        -k|--keep-providers)
+        KEEP_PROVIDERS=1
+        shift
+        ;;
+        *)
+        echo "Unrecognized argument: $1"
+        shift
+        ;;
+    esac
+done
+
+
 # Make sure `oc login` has been done and `oc` command is working
 echo "Testing connection"
 oc version >/dev/null 2>&1
@@ -21,7 +46,7 @@ printf "\n"
 oc cluster-info | head -n 1 | awk '{print $NF}'
 printf "\n"
 
-./clean-clusters.sh
+./clean-clusters.sh "$args"
 
 kubectl delete -k multiclusterhub/
 echo "Sleeping for 200 seconds to allow resources to finalize ..."


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Originally the uninstall script would leave provider connections if they existed outside ACM namespaces.  We felt this was not good to leave provider connection secrets lying around, so we added cleanup code to uninstall.  However, many developers take advantage of the ability to create provider connections in the default namespace and have them persist across uninstall/install.

This change adds a flag to the uninstall script to allow the extra provider connections to be kept.  Default behavior is still to delete them.

**Motivation for the change:**
Change for issue https://github.com/open-cluster-management/backlog/issues/5095
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->