### PR TITLE
Add the name of the secret that must be edited for downstream builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ spec:
     source: registry.access.redhat.com/openshift4/ose-oauth-proxy
 ```
 
-2. Ensure that the main pull secret for your OpenShift cluster has pull access to `quay.io/acm-d` in an entry for `quay.io:443`.  Your main pull secret should look something like this (**Caution**: if you apply this on a pre-existing cluster, it will cause a rolling restart of all nodes).  You have to edit the pull secret via the `oc` cli, OpenShift console (recommended) or [bootstrap repo](https://github.com/open-cluster-management/bootstrap#how-to-use) at cluster create time:
+2. Ensure that the main pull secret for your OpenShift cluster has pull access to `quay.io/acm-d` in an entry for `quay.io:443`.  Your main pull secret should look something like this (**Caution**: if you apply this on a pre-existing cluster, it will cause a rolling restart of all nodes).  You have to edit the pull secret to include the section detailed below via the oc cli: `oc edit secret/pull-secret -n openshift-config`, OpenShift console, or [bootstrap repo](https://github.com/open-cluster-management/bootstrap#how-to-use) at cluster create time:
     <pre>
     {
       "auths": {


### PR DESCRIPTION
## Summary

We should update the readme to include the name of the pull secret that must be edited on a live cluster in order to install a downstream build!