### PR TITLE
Adding in a step to remove the open-cluster-management namespace on uninstall

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -60,4 +60,7 @@ kubectl delete -k acm-operator/
 
 kubectl delete -k community-subscriptions/
 
+echo "Cleaning up the open-cluster-management namespace.."
+oc delete namespace open-cluster-management
+
 exit 0


### PR DESCRIPTION
**Description of the change:**

This adds an additional step to uninstall.sh to remove the open-cluster-management namespace upon uninstall.

**Motivation for the change:**

When trying to deploy downstream acm-d builds, I wanted to try a newer version, so I ran uninstall.sh but it appeared that I had to go further than what this script did to successfully re-run ./start.sh with a different release version. Once I'd deleted the namespace I was good to go.

I suspect that there's a reason why we don't want to clear up the namespace so suspect this PR will be rejected... but would be good to understand whether start.sh needs further work if a deployment has already been uninstalled prior?