### PR TITLE
fix downstream rc deployments

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -191,7 +191,9 @@ ${SED} -i "s|channel: .*$|channel: ${SUBSCRIPTION_CHANNEL}|g" ./$OPERATOR_DIRECT
 echo "* Applying MODE to multiclusterhub-operator subscription"
 ${SED} -i "s|installPlanApproval: .*$|installPlanApproval: ${MODE}|g" ./$OPERATOR_DIRECTORY/subscription.yaml
 if [[ "$MODE" == "Automatic" ]]; then
-    STARTING_CSV="advanced-cluster-management.v${SNAPSHOT_PREFIX}"
+    # Issue 7436 - If Downstream RC snapshot, remove leading 'v' from prefix name
+    CLEAN_RC_PREFIX=$(echo ${SNAPSHOT_PREFIX} | ${SED} 's/v//')
+    STARTING_CSV="advanced-cluster-management.v${CLEAN_RC_PREFIX}"
     echo "* Applying STARTING_CSV to multiclusterhub-operator-subscription ($STARTING_CSV)"
     ${SED} -i "s|startingCSV: .*$|startingCSV: ${STARTING_CSV}|g" ./$OPERATOR_DIRECTORY/subscription.yaml
 elif [[ "$MODE" == "Manual" ]]; then


### PR DESCRIPTION
**Description of the change:**
Added filter for `RC` named snapshots when deploying from downstream to remove the extra `v` i.e. `v2.1.1-RC4`

**Motivation for the change:**
When deploying an `RC` snapshot from downstream the extra `v` in the snapshot name was causing an extra `v` to appear in the `STARTING_CSV` variable i.e. `STARTING_CSV=advanced-cluster-management.vv2.1.1-RC4` 

This fix will ensure the removal of the extra `v` i.e. `STARTING_CSV=advanced-cluster-management.v2.1.1-RC4`

Closes #7436