### PR TITLE
fix cleanup for new label in credentials

### DIFF
--- a/clean-clusters.sh
+++ b/clean-clusters.sh
@@ -115,10 +115,16 @@ sleep 5
 
 if [ "$KEEP_PROVIDERS" -eq 1 ]; then
    echo "Keeping the following provider connections"
+   # 2.2 and older
    oc get secrets -l cluster.open-cluster-management.io/provider --ignore-not-found -A
+   # 2.3 and newer
+   oc get secrets -l cluster.open-cluster-management.io/credentials --ignore-not-found -A
 else
    echo "Deleting provider connections"
+   # 2.2 and older
    oc delete secrets -l cluster.open-cluster-management.io/provider --ignore-not-found -A
+   # 2.3 and newer
+   oc delete secrets -l cluster.open-cluster-management.io/credentials --ignore-not-found -A
 fi
 
 


### PR DESCRIPTION
Signed-off-by: Chris Ahl <cahl@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Need to update the uninstall to cleanup any credentials that are using the new label (as of 2.3)


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->