### PR TITLE
Update owners file to unblock prow config

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,9 @@
 approvers:
 - gurnben
-- mdelder
 - tpouyer
 - Kyl-Bempah
 
 reviewers:
 - gurnben
-- mdelder
 - tpouyer
 - Kyl-Bempah


### PR DESCRIPTION
## Summary of Changes

This PR removes mdelder from the owners file to unblock [this PR](https://github.com/openshift/release/pull/19104#issuecomment-857010241) which drives OSCI Prow configuration for this repo.  