### PR TITLE
Update README to include accepting invitation at quay.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Either way you choose to go, you are going to need a `pull-secret`. We are still
 
 2. Generate your pull-secret:
    - ensure you have access to the quay org ([open-cluster-management](https://quay.io/repository/open-cluster-management/multiclusterhub-operator-index?tab=tags))
-     - to request access to [open-cluster-management](https://quay.io/repository/open-cluster-management/multiclusterhub-operator-index?tab=tags) in quay.io please contact the ACM CICD team via email at [acm-contact@redhat.com](mailto:acm-contact@redhat.com) or, if you have access to Red Hat CoreOS Slack you can contact us on our Slack Channel [#forum-acm-devops](https://coreos.slack.com/archives/CSZLMKPS5)).
+     - to request access to [open-cluster-management](https://quay.io/repository/open-cluster-management/multiclusterhub-operator-index?tab=tags) in quay.io please contact the ACM CICD team via email at [acm-contact@redhat.com](mailto:acm-contact@redhat.com) or, if you have access to Red Hat CoreOS Slack you can contact us on our Slack Channel [#forum-acm-devops](https://coreos.slack.com/archives/CSZLMKPS5)). Once the team indicates they've granted you access, open your Notifications at quay.io and accept the invitation(s) waiting for you.
    - go to [https://quay.io/user/tpouyer?tab=settings](https://quay.io/user/tpouyer?tab=settings) replacing `tpouyer` with your username
    - click on `Generate Encrypted Password`
    - enter your quay.io password


### PR DESCRIPTION
**Description of the change:**
Update README to include accepting invitation at quay.io after CICD team gives you access.

**Motivation for the change:**
I've never used quay.io before and didn't know this step was needed. My first try at a deploy failed as a result.