### PR TITLE
add skip capabilities to installation based on environment variables

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -129,6 +129,8 @@ EOF
 
 fi
 
+if [[ -z $SKIP_OPERATOR_INSTALL ]]; then
+
 DEFAULT_SNAPSHOT="MUST_PROVIDE_SNAPSHOT"
 if [ -f ./snapshot.ver ]; then
     DEFAULT_SNAPSHOT=`cat ./snapshot.ver`
@@ -283,8 +285,13 @@ if [[ "$MODE" == "Manual" ]]; then
 fi
 
 waitForPod "multiclusterhub-operator" "${CUSTOM_REGISTRY_IMAGE}"
-printf "\n* Beginning deploy...\n"
 
+
+fi
+
+if [[ -z $SKIP_MCH_INSTALL ]]; then
+
+printf "\n* Beginning deploy...\n"
 
 echo "* Applying the multiclusterhub-operator to install Red Hat Advanced Cluster Management for Kubernetes"
 kubectl apply -k applied-mch -n ${TARGET_NAMESPACE}
@@ -398,3 +405,4 @@ else
   echo "Deploying, for 2.1+ releases monitor the status of the multiclusterhub created in the ${TARGET_NAMESPACE} namespace, for 2.0 releases use \"watch oc -n ${TARGET_NAMESPACE} get pods\" to monitor progress. Expect around ${TOTAL_POD_COUNT} pods."
 fi
 
+fi


### PR DESCRIPTION
Signed-off-by: Cameron Wall <cwall@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

I added two bracketed if statements allowing the installation of the operator and multi-cluster hub to be skipped based on passing in environment variables.

**Motivation for the change:**
In order to make changes to the CICD Canary tests, it was necessary to have the ability to split the installation of the operator and MCH
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->