### PR TITLE
Use helpers.sh for waitForPod function and add early exit on `ImagePullBackoff`

### DIFF
--- a/brew-start.sh
+++ b/brew-start.sh
@@ -7,7 +7,8 @@
 
 
 #-----BOOTSTRAP HELPERS-----#
-source dev/lib/helpers.sh
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$DIR/lib/helpers.sh"
 
 
 #-----PREPARATION & VARS-----#

--- a/brew-start.sh
+++ b/brew-start.sh
@@ -7,7 +7,7 @@
 
 
 #-----BOOTSTRAP HELPERS-----#
-source helpers.sh
+source dev/lib/helpers.sh
 
 
 #-----PREPARATION & VARS-----#
@@ -154,7 +154,7 @@ printf "${CLEAR}"
 
 #-----WAIIT FOR OPERATOR TO BECOME AVAILABLE-----#
 #### Use our helper to wait for the operator
-waitForPod "multiclusterhub-operator" "${SUBSCRIPTION_NAME}"
+waitForPod "multiclusterhub-operator" "${SUBSCRIPTION_NAME}" "\([0-9]\+\)\/\1"
 
 
 #-----CREATE A MULTICLUSTERHUB-----#
@@ -175,7 +175,7 @@ printf "${CLEAR}"
 
 #-----WAIT FOR THE MCH INSTALL TO COMPLETE-----#
 #### Use our helper to wait for the multicluster-operators-application to become ready
-waitForPod "multicluster-operators-application" ""
+waitForPod "multicluster-operators-application" "" "\([0-9]\+\)\/\1"
 
 #### Poll for the MCH status to become ready
 printf "${BLUE}Polling MCH status.${CLEAR}\n"

--- a/dev/lib/helpers.sh
+++ b/dev/lib/helpers.sh
@@ -27,31 +27,33 @@ function waitForPod() {
     # Arguments:
     #       podname ($1) - the name of the pod to poll for
     #       ignore  ($2) - pod names to ignore (grep string)
+    #       running ($3) - regex to check if all pod replicas are ready
     FOUND=1
     MINUTE=0
     podName=$1
     ignore=$2
     running="$3"
-    printf "\n#####\nWait for ${TARGET_NAMESPACE}/${podName} to reach running state (4min).\n"
+    printf "${BLUE}Waiting for ${TARGET_NAMESPACE}/${podName} to reach running state (4min).\n${CLEAR}"
     while [ ${FOUND} -eq 1 ]; do
         # Wait up to 4min, should only take about 20-30s
         if [ $MINUTE -gt 240 ]; then
-            echo "Timeout waiting for the ${podName}. Try cleaning up using the uninstall scripts before running again."
-            echo "List of current pods:"
-            oc -n ${TARGET_NAMESPACE} get pods
-            echo
-            echo "You should see ${podName}, multiclusterhub-repo, and multicloud-operators-subscription pods"
+            printf "${YELLOW}Timeout waiting for the ${podName}. Try cleaning up using the uninstall scripts before running again.${CLEAR}\n"
+            printf "${YELLOW}List of current pods:${CLEAR}\n"
+            printf "${YELLOW}"
+            oc -n "${TARGET_NAMESPACE}" get pods
+            printf "${CLEAR}"
+            printf "${BLUE}You should see ${podName}, multiclusterhub-repo, and multicloud-operators-subscription pods.${CLEAR}\n"
             exit 1
         fi
 
         if [[ "$ignore" == "" ]]; then
-            operatorPod=`oc -n ${TARGET_NAMESPACE} get pods | grep ${podName}`
+            operatorPod=$(oc -n "${TARGET_NAMESPACE}" get pods | grep "${podName}")
         else
-            operatorPod=`oc -n ${TARGET_NAMESPACE} get pods | grep ${podName} | grep -v ${ignore}`
+            operatorPod=$(oc -n "${TARGET_NAMESPACE}" get pods | grep "${podName}" | grep -v "${ignore}")
         fi
 
         if [[ "$operatorPod" =~ "${running}     Running" ]]; then
-            echo "* ${podName} is running"
+            printf "${BLUE}* ${podName} is running${CLEAR}\n"
             break
         elif [[ "$operatorPod" =~ "ImagePullBackOff" ]]; then
             echo "ERROR: ${TARGET_NAMESPACE}/${podName} has ImagePullBackOff"
@@ -59,7 +61,7 @@ function waitForPod() {
         elif [[ "$operatorPod" == "" ]]; then
             operatorPod="Waiting"
         fi
-        echo "* STATUS: $operatorPod"
+        printf "${BLUE}* STATUS: $operatorPod${CLEAR}\n"
         sleep 3
         (( MINUTE = MINUTE + 3 ))
     done

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -7,43 +7,12 @@
 # ./start.sh --silent, this skips any questions, using the local files to apply the snapshot and secret
 # ./start.sh --watch, this monitors for status during the main deploy of Red Hat ACM
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$DIR/lib/helpers.sh"
+
 # CONSTANTS
 TOTAL_POD_COUNT_1X=35
 TOTAL_POD_COUNT_2X=55
-
-function waitForPod() {
-    FOUND=1
-    MINUTE=0
-    podName=$1
-    ignore=$2
-    running="$3"
-    printf "\n#####\nWait for ${podName} to reach running state (4min).\n"
-    while [ ${FOUND} -eq 1 ]; do
-        # Wait up to 4min, should only take about 20-30s
-        if [ $MINUTE -gt 240 ]; then
-            echo "Timeout waiting for the ${podName}. Try cleaning up using the uninstall scripts before running again."
-            echo "List of current pods:"
-            oc -n ${TARGET_NAMESPACE} get pods
-            echo
-            echo "You should see ${podName}, multiclusterhub-repo, and multicloud-operators-subscription pods"
-            exit 1
-        fi
-        if [ "$ignore" == "" ]; then
-            operatorPod=`oc -n ${TARGET_NAMESPACE} get pods | grep ${podName}`
-        else
-            operatorPod=`oc -n ${TARGET_NAMESPACE} get pods | grep ${podName} | grep -v ${ignore}`
-        fi
-        if [[ "$operatorPod" =~ "${running}     Running" ]]; then
-            echo "* ${podName} is running"
-            break
-        elif [ "$operatorPod" == "" ]; then
-            operatorPod="Waiting"
-        fi
-        echo "* STATUS: $operatorPod"
-        sleep 3
-        (( MINUTE = MINUTE + 3 ))
-    done
-}
 
 # fix sed issue on mac
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
 - Move `helpers.sh` to `dev/lib/helpers.sh`
 - Use `waitForPod` from centralized location in all start scripts
 - Exit early if an ImagePullBackoff is detected

