### PR TITLE
Revert "Use helpers.sh for waitForPod function and add early exit on `ImagePullBackoff`" temporarily

### DIFF
--- a/brew-start.sh
+++ b/brew-start.sh
@@ -7,8 +7,7 @@
 
 
 #-----BOOTSTRAP HELPERS-----#
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$DIR/lib/helpers.sh"
+source helpers.sh
 
 
 #-----PREPARATION & VARS-----#
@@ -155,7 +154,7 @@ printf "${CLEAR}"
 
 #-----WAIIT FOR OPERATOR TO BECOME AVAILABLE-----#
 #### Use our helper to wait for the operator
-waitForPod "multiclusterhub-operator" "${SUBSCRIPTION_NAME}" "\([0-9]\+\)\/\1"
+waitForPod "multiclusterhub-operator" "${SUBSCRIPTION_NAME}"
 
 
 #-----CREATE A MULTICLUSTERHUB-----#
@@ -176,7 +175,7 @@ printf "${CLEAR}"
 
 #-----WAIT FOR THE MCH INSTALL TO COMPLETE-----#
 #### Use our helper to wait for the multicluster-operators-application to become ready
-waitForPod "multicluster-operators-application" "" "\([0-9]\+\)\/\1"
+waitForPod "multicluster-operators-application" ""
 
 #### Poll for the MCH status to become ready
 printf "${BLUE}Polling MCH status.${CLEAR}\n"

--- a/helpers.sh
+++ b/helpers.sh
@@ -27,38 +27,32 @@ function waitForPod() {
     # Arguments:
     #       podname ($1) - the name of the pod to poll for
     #       ignore  ($2) - pod names to ignore (grep string)
-    #       running ($3) - regex to check if all pod replicas are ready
     FOUND=1
     MINUTE=0
     podName=$1
     ignore=$2
-    running="$3"
-    printf "${BLUE}Waiting for ${TARGET_NAMESPACE}/${podName} to reach running state (4min).\n${CLEAR}"
+    running="\([0-9]\+\)\/\1"
+    printf "${BLUE}Waiting for ${podName} to reach running state (4min).\n${CLEAR}"
     while [ ${FOUND} -eq 1 ]; do
         # Wait up to 4min, should only take about 20-30s
         if [ $MINUTE -gt 240 ]; then
             printf "${YELLOW}Timeout waiting for the ${podName}. Try cleaning up using the uninstall scripts before running again.${CLEAR}\n"
             printf "${YELLOW}List of current pods:${CLEAR}\n"
             printf "${YELLOW}"
-            oc -n "${TARGET_NAMESPACE}" get pods
+            oc -n ${TARGET_NAMESPACE} get pods
             printf "${CLEAR}"
             printf "${BLUE}You should see ${podName}, multiclusterhub-repo, and multicloud-operators-subscription pods.${CLEAR}\n"
             exit 1
         fi
-
-        if [[ "$ignore" == "" ]]; then
-            operatorPod=$(oc -n "${TARGET_NAMESPACE}" get pods | grep "${podName}")
+        if [ "$ignore" == "" ]; then
+            operatorPod=`oc -n ${TARGET_NAMESPACE} get pods | grep ${podName}`
         else
-            operatorPod=$(oc -n "${TARGET_NAMESPACE}" get pods | grep "${podName}" | grep -v "${ignore}")
+            operatorPod=`oc -n ${TARGET_NAMESPACE} get pods | grep ${podName} | grep -v ${ignore}`
         fi
-
-        if [[ "$operatorPod" =~ "${running}     Running" ]]; then
+        if [[ $(echo $operatorPod | grep "${running}") ]]; then
             printf "${BLUE}* ${podName} is running${CLEAR}\n"
             break
-        elif [[ "$operatorPod" =~ "ImagePullBackOff" ]]; then
-            echo "ERROR: ${TARGET_NAMESPACE}/${podName} has ImagePullBackOff"
-            exit 1
-        elif [[ "$operatorPod" == "" ]]; then
+        elif [ "$operatorPod" == "" ]; then
             operatorPod="Waiting"
         fi
         printf "${BLUE}* STATUS: $operatorPod${CLEAR}\n"

--- a/start.sh
+++ b/start.sh
@@ -7,9 +7,6 @@
 # ./start.sh --silent, this skips any questions, using the local files to apply the snapshot and secret
 # ./start.sh --watch, this monitors for status during the main deploy of Red Hat ACM
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$DIR/dev/lib/helpers.sh"
-
 # CONSTANTS
 TOTAL_POD_COUNT_1X=35
 TOTAL_POD_COUNT_2X=55
@@ -35,6 +32,40 @@ function waitForInstallPlan() {
         fi
         echo 'waiting for installplan to show'
         sleep 10
+    done
+}
+
+function waitForPod() {
+    FOUND=1
+    MINUTE=0
+    podName=$1
+    ignore=$2
+    running="\([0-9]\+\)\/\1"
+    printf "\n#####\nWait for ${podName} to reach running state (4min).\n"
+    while [ ${FOUND} -eq 1 ]; do
+        # Wait up to 4min, should only take about 20-30s
+        if [ $MINUTE -gt 240 ]; then
+            echo "Timeout waiting for the ${podName}. Try cleaning up using the uninstall scripts before running again."
+            echo "List of current pods:"
+            oc -n ${TARGET_NAMESPACE} get pods
+            echo
+            echo "You should see ${podName}, multiclusterhub-repo, and multicloud-operators-subscription pods"
+            exit 1
+        fi
+        if [ "$ignore" == "" ]; then
+            operatorPod=`oc -n ${TARGET_NAMESPACE} get pods | grep ${podName}`
+        else
+            operatorPod=`oc -n ${TARGET_NAMESPACE} get pods | grep ${podName} | grep -v ${ignore}`
+        fi
+        if [[ $(echo $operatorPod | grep "${running}") ]]; then
+            echo "* ${podName} is running"
+            break
+        elif [ "$operatorPod" == "" ]; then
+            operatorPod="Waiting"
+        fi
+        echo "* STATUS: $operatorPod"
+        sleep 3
+        (( MINUTE = MINUTE + 3 ))
     done
 }
 
@@ -122,7 +153,7 @@ if [ "${DEFAULT_SNAPSHOT}" == "MUST_PROVIDE_SNAPSHOT" ]; then
 fi
 SNAPSHOT_PREFIX=${DEFAULT_SNAPSHOT%%\-*}
 
-# If the user sets the COMPOSITE_BUNDLE flag to "true", then set to the `acm` variants of variables, otherwise the multicluster-hub version.
+# If the user sets the COMPOSITE_BUNDLE flag to "true", then set to the `acm` variants of variables, otherwise the multicluster-hub version.  
 if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then OPERATOR_DIRECTORY="acm-operator"; else OPERATOR_DIRECTORY="multicluster-hub-operator"; fi;
 if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then CUSTOM_REGISTRY_IMAGE="acm-custom-registry"; else CUSTOM_REGISTRY_IMAGE="multicluster-hub-custom-registry"; fi;
 
@@ -251,13 +282,13 @@ if [[ "$MODE" == "Manual" ]]; then
     oc patch InstallPlan $INSTALL_PLAN -n ${TARGET_NAMESPACE} --type "json" -p '[{"op":"replace","path":"/spec/approved","value":true}]'
 fi
 
-waitForPod "multiclusterhub-operator" "${CUSTOM_REGISTRY_IMAGE}" "\([0-9]\+\)\/\1"
+waitForPod "multiclusterhub-operator" "${CUSTOM_REGISTRY_IMAGE}"
 printf "\n* Beginning deploy...\n"
 
 
 echo "* Applying the multiclusterhub-operator to install Red Hat Advanced Cluster Management for Kubernetes"
 kubectl apply -k applied-mch -n ${TARGET_NAMESPACE}
-waitForPod "multicluster-operators-application" "" "\([0-9]\+\)\/\1"
+waitForPod "multicluster-operators-application" ""
 
 COMPLETE=1
 if [[ " $@ " =~ " --watch " ]]; then


### PR DESCRIPTION
Reverts open-cluster-management/deploy#208

This seems to have broken [CI Jobs](https://app.travis-ci.com/github/open-cluster-management/canary/jobs/541138861) so let's revert and I'll test this afternoon and find a patch.  This regex _should have_ worked!