### PR TITLE
Remove `router-default` from canonical hostname

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -101,7 +101,8 @@ if [ $? -ne 0 ]; then
     exit 2
 fi
 #Shorten to the basedomain
-HOST_URL=${HOST_URL/apps./}
+HOST_URL=${HOST_URL/#router-default./}
+HOST_URL=${HOST_URL/#apps./}
 echo "* Using baseDomain: ${HOST_URL}"
 VER=`oc version | grep "Client Version:"`
 echo "* oc CLI ${VER}"


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
- Remove `router-default` from canonical hostname (if it exists)

**Motivation for the change:**
- The canonical hostname seems to begin with `router-default.apps.`
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->