### PR TITLE
Add creation of IDPConfig CR as part of start.sh for idp-management

### DIFF
--- a/idp-management/identityconfig_v1alpha1_idpconfig.yaml
+++ b/idp-management/identityconfig_v1alpha1_idpconfig.yaml
@@ -1,0 +1,6 @@
+apiVersion: identityconfig.identitatem.io/v1alpha1
+kind: IDPConfig
+metadata:
+  name: idp-config
+  namespace: idp-mgmt-config
+spec: {}

--- a/idp-management/start.sh
+++ b/idp-management/start.sh
@@ -82,6 +82,7 @@ done
 
 if [ $_apiReady -eq 1 ]; then
   oc apply -f idp-management/identityconfig_v1alpha1_idpconfig.yaml
+  sleep 5
   echo "identity configuration management installed successfully"
 else
   echo "identity configuration management subscription could not install in the allotted time."

--- a/idp-management/start.sh
+++ b/idp-management/start.sh
@@ -81,6 +81,7 @@ for run in {1..10}; do
 done
 
 if [ $_apiReady -eq 1 ]; then
+  oc apply -f idp-management/identityconfig_v1alpha1_idpconfig.yaml
   echo "identity configuration management installed successfully"
 else
   echo "identity configuration management subscription could not install in the allotted time."


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Creation of IDPConfig CR as part of installation of `identity configuration management for Kubernetes` operator.

**Motivation for the change:**
Some of this is based on the Zenhub issue https://github.com/open-cluster-management/backlog/issues/18373 
When the `IDPConfig` CR is created the idp installer controller will trigger the install of the the idp-mgmt-operator, the webhook and the dex-operator.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->